### PR TITLE
Syntax fixes for activities five on eng_us and pt_br versions

### DIFF
--- a/eng_us/Seen5-Following_System_Call_KILL-English.txt
+++ b/eng_us/Seen5-Following_System_Call_KILL-English.txt
@@ -80,7 +80,7 @@ Step 9 - TEST 2
 int main() {
 	int pid;
 	printf("\nPID to kill: ");
-	scanf("&d",&pid);
+	scanf("%d",&pid);
 	kill(pid,9);
 	return 0;
 }

--- a/pt_br/Atividade5-Rastreando_Chamada_de_Sistema_KILL-Portuguese.txt
+++ b/pt_br/Atividade5-Rastreando_Chamada_de_Sistema_KILL-Portuguese.txt
@@ -80,7 +80,7 @@ Passo 9 - TEST 2
 int main() {
 	int pid;
 	printf("\nPID to kill: ");
-	scanf("&d",&pid);
+	scanf("%d",&pid);
 	kill(pid,9);
 	return 0;
 }


### PR DESCRIPTION
Minor syntax fix on last activity, on string of scanf() function formatt operator '%' instead the reference operator '&'. 
